### PR TITLE
Update class.access_control.php - SQL rex_media_type escaped!

### DIFF
--- a/lib/class.access_control.php
+++ b/lib/class.access_control.php
@@ -129,8 +129,9 @@ public static function guardian_permissions($uid,$permkey) {
    #                      =self::perm_media (access to media categories)
    #
    $sql=rex_sql::factory();
-   $query='SELECT role FROM rex_user WHERE id='.$uid;
-   $row=$sql->getArray($query);
+   $query='SELECT role FROM rex_user WHERE id= :id';
+   $params = ['id'=> $uid];
+   $row=$sql->getArray($query,$params);
    $rolestr=$row[0]['role'];
    $role=explode(',',$rolestr);
    #
@@ -140,7 +141,8 @@ public static function guardian_permissions($uid,$permkey) {
    $pmcol='';
    for($i=0;$i<count($role);$i=$i+1):
       if(empty($role[$i])) continue;
-      $query='SELECT perms FROM rex_user_role WHERE id='.$role[$i];
+      $query='SELECT perms FROM rex_user_role WHERE id= :id';
+      $params = ['id'=> $role[$i]];
       $row=$sql->getArray($query);
       $perms=$row[0]['perms'];
       $arr=json_decode($perms,TRUE);
@@ -613,8 +615,9 @@ public static function top_parent_media_category($mediatype,$file) {
      #     top media category already defined?
      $sql=rex_sql::factory();
      $table=rex::getTablePrefix().'media_category';
-     $query='SELECT id FROM '.$table.' WHERE parent_id=0 AND name=\''.$topdir.'\'';
-     $sql->setQuery($query);
+     $query='SELECT id FROM '.$table.' WHERE parent_id=0 AND name=:name';
+     $params = ['name'=>$topdir];
+     $sql->setQuery($query,$params);
      if($sql->getRows()>0) $topmedcatid=$sql->getValue('id');
      endif;
    return $topmedcatid;
@@ -787,7 +790,7 @@ public static function get_rex_user($uid) {
    if($uid<=0) return array();
    #
    $sql=rex_sql::factory();
-   $users=$sql->getArray('SELECT login,password FROM rex_user WHERE id='.$uid);
+   $users=$sql->getArray('SELECT login,password FROM rex_user WHERE id= :id',['id'=>$uid]);
    if(count($users)>0) return $users[0];
    return array();
    }


### PR DESCRIPTION
**Request-Uri:** /en/index.php?rex_media_type=IMG980%27nvOpzp;%20AND%201=1%20OR%20(%3C%27%22%3EiKO)),&rex_media_file=image.jpg%27nvOpzp;%20AND%201=1%20OR%20(%3C%27%22%3EiKO))
**Request-Method:** GET

**rex_sql_exception:** Error while executing statement "SELECT id FROM rex_media_category WHERE parent_id=0 AND name='ZZmedia:IMG980'nvOpzp; AND 1=1 OR (<'">iKO)),'" using params []! SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'nvOpzp; AND 1=1 OR (<'">iKO)),'' at line 1
**File:** redaxo/src/core/lib/sql/sql.php
**Line:** 406

<details>
<summary>Stacktrace</summary>

| Function | File | Line |
| ----------------------------------------- | ------------------------------------------------------------- | -------- |
| rex_sql->execute | redaxo/src/core/lib/sql/sql.php | 449 |
| rex_sql->setQuery | redaxo/src/addons/access_control/lib/class.access_control.php | 617 |
| access_control::top_parent_media_category | redaxo/src/addons/access_control/lib/class.access_control.php | 571 |
| access_control::media_guardian_users | redaxo/src/addons/access_control/lib/class.access_control.php | 515 |
| access_control::control_file | redaxo/src/addons/access_control/boot.php | 14 |
| require | redaxo/src/core/lib/packages/package.php | 233 |
| rex_package->includeFile | redaxo/src/core/lib/packages/package.php | 395 |
| rex_package->boot | redaxo/src/core/packages.php | 25 |
| {closure} | redaxo/src/core/lib/util/timer.php | 56 |
| rex_timer::measure | redaxo/src/core/packages.php | 24 |
| {closure} | redaxo/src/core/lib/util/timer.php | 56 |
| rex_timer::measure | redaxo/src/core/packages.php | 22 |
| include_once | redaxo/src/core/frontend.php | 12 |
| require | redaxo/src/core/boot.php | 155 |
| require | index.php | 9 |

</details>
<details>
<summary>System report (REDAXO 5.15.1, PHP 8.2.10, MariaDB 10.6.15)</summary>

| REDAXO | |
| ------------: | :--------- |
| Version | 5.15.1 |


| PHP | |
| ------------: | :--------- |
| Version | 8.2.10 |
| OPcache | yes |
| Xdebug | no |


| Database | |
| ------------: | :-------------- |
| Version | MariaDB 10.6.15 |
| Character set | utf8 |


| Server | |
| ------------: | :------------ |
| OS | Linux |
| SAPI | cgi-fcgi |
| Webserver | Apache/2.4.57 |


| Request | |
| ------------: | :--------------- |
| Browser | Chrome/117.0.0.0 |
| Protocol | HTTP/1.1 |
| HTTPS | yes |


| Packages | |
| ----------------------: | :--------- |
| AtecHtaccess | v1.02 |
| AtecImageOptim | v1.02 |
| access_control | 2.5.2 |
| adminer | 1.9.3 |
| arttec_agenturtool | 1.1.7 |
| backup | 2.9.0 |
| be_arttec_customizer | 1.0.1 |
| be_style | 3.2.0 |
| be_style/redaxo | 3.2.0 |
| bloecks | 3.1.1 |
| bloecks/cutncopy | 3.1.1 |
| bloecks/dragndrop | 3.1.1 |
| bloecks/status | 3.1.1 |
| cronjob | 2.10.0 |
| cronjob/article_status | 2.10.0 |
| cronjob/optimize_tables | 2.10.0 |
| developer | 3.9.2 |
| event_cal | 1.1.3 |
| install | 2.11.1 |
| markitup | 3.7.4 |
| markitup/documentation | 1.1.0 |
| mblock | 3.4.13 |
| media_manager | 2.14.0 |
| mediapool | 2.13.0 |
| metainfo | 2.10.0 |
| minify | 2.2.1 |
| phpmailer | 2.12.0 |
| project | dev |
| quick_navigation | 6.1.0 |
| search_it | 6.9.8 |
| search_it/documentation | 6.9.8 |
| search_it/plaintext | 6.9.8 |
| search_it/stats | 6.9.8 |
| sprog | 1.5.1 |
| structure | 2.15.0 |
| structure/content | 2.15.0 |
| structure/history | 2.15.0 |
| tinymce4 | 1.2.1 |
| users | 2.10.0 |
| ydeploy | 1.2.0 |
| yform | 4.1.1 |
| yform/docs | 2.3 |
| yform/email | 4.1.1 |
| yform/manager | 4.1.1 |
| yform_spam_protection | 1.2.3 |
| yform_usability | 2.1.3 |
| yrewrite | 2.10.0 |

</details>